### PR TITLE
Fix invalid imports in admin controllers

### DIFF
--- a/sky-server/src/main/java/com/sky/controller/admin/OrderController.java
+++ b/sky-server/src/main/java/com/sky/controller/admin/OrderController.java
@@ -13,7 +13,6 @@ import com.sky.vo.OrderVO;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.Put;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 

--- a/sky-server/src/main/java/com/sky/controller/admin/ReportController.java
+++ b/sky-server/src/main/java/com/sky/controller/admin/ReportController.java
@@ -6,7 +6,6 @@ import com.sky.service.ReportService;
 import com.sky.vo.*;
 import io.swagger.annotations.Api;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.Get;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;


### PR DESCRIPTION
## Summary
- remove unused Apache Commons imports from `OrderController` and `ReportController`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f9d17050832aa087f98c66935cff